### PR TITLE
Updated error messages and identifiers

### DIFF
--- a/Compiler/src/BuildTokens.cpp
+++ b/Compiler/src/BuildTokens.cpp
@@ -22,7 +22,7 @@ int main(int argv, char* argc[])
 	catch (const std::exception& e)
 	{
 		//Print Error Message
-		cout << e.what() << endl;
+		cout << endl << e.what() << endl;
 		return 1;
 	}
     return 0;

--- a/Compiler/src/header/Scanner.h
+++ b/Compiler/src/header/Scanner.h
@@ -29,8 +29,6 @@ private:
 
 	const map<string, TokenType> GenericKeywordTypeMap{
 		{ "function", PRIMITIVE_KEYWORD},
-		{ "main", PRIMITIVE_KEYWORD},
-		{ "print", PRIMITIVE_KEYWORD},
 		{ "and", LOGICIAL_OPERATOR},
 		{ "or", LOGICIAL_OPERATOR},
 		{ "not", LOGICIAL_OPERATOR},

--- a/Compiler/src/implementation/Scanner.cpp
+++ b/Compiler/src/implementation/Scanner.cpp
@@ -338,7 +338,6 @@ void Scanner::ignoreComment()
 		FilePosition++;
 	}
 
-	ostringstream ErrorMessageStream;
-	ErrorMessageStream << "ERROR: You forgot to close you're comment that started at pos. " << InitialCommentPosition;
-	throw  std::runtime_error(ErrorMessageStream.str());
+	string ErrorMessage ="ERROR: You forgot to close you're comment that started at pos. " + to_string(InitialCommentPosition);
+	throw runtime_error(ErrorMessage);
 }

--- a/Compiler/test/ScannerTest.cpp
+++ b/Compiler/test/ScannerTest.cpp
@@ -78,10 +78,10 @@ TEST_CASE("Scanner next() returns PARENTHESIS Token With Correct Value for (", "
 }
 
 TEST_CASE("Scanner next() returns PARENTHESIS Tokens correctly directly after keyword.", "[Scanner]") {
-	string TestFileContents = "main()";
+	string TestFileContents = "function()";
 	Scanner Scanner(TestFileContents, true);
 
-	assertScannerHasNextTokenOfTypeWithValue(Scanner, PRIMITIVE_KEYWORD, "main");
+	assertScannerHasNextTokenOfTypeWithValue(Scanner, PRIMITIVE_KEYWORD, "function");
 	assertScannerHasNextTokenOfTypeWithValue(Scanner, PARENTHESIS, "(");
 	assertScannerHasNextTokenOfTypeWithValue(Scanner, PARENTHESIS, ")");
 	assertScannerHasNextTokenOfType(Scanner, END_OF_FILE);
@@ -215,11 +215,11 @@ TEST_CASE("Scanner next() Returns IDENTIFIER for 'Function' with the Correct Val
 	assertScannerHasNextTokenOfTypeWithValue(Scanner, IDENTIFIER, "Function");
 }
 
-TEST_CASE("Scanner next() Returns PRIMITIVE_KEYWORD for 'main' with the Correct Value", "[Scanner]") {
+TEST_CASE("Scanner next() Returns IDENTIFIER for 'main' with the Correct Value", "[Scanner]") {
 	string TestFileContents = "main";
 	Scanner Scanner(TestFileContents, true);
 
-	assertScannerHasNextTokenOfTypeWithValue(Scanner, PRIMITIVE_KEYWORD, "main");
+	assertScannerHasNextTokenOfTypeWithValue(Scanner, IDENTIFIER, "main");
 }
 
 TEST_CASE("Scanner next() Returns IDENTIFIER for 'Main' with the Correct Value (AND NOT A PRIMITIVE KEYWORD)", "[Scanner]") {
@@ -229,11 +229,11 @@ TEST_CASE("Scanner next() Returns IDENTIFIER for 'Main' with the Correct Value (
 	assertScannerHasNextTokenOfTypeWithValue(Scanner, IDENTIFIER, "Main");
 }
 
-TEST_CASE("Scanner next() Returns PRIMITIVE_KEYWORD for 'print' with the Correct Value", "[Scanner]") {
+TEST_CASE("Scanner next() Returns IDENTIFIER for 'print' with the Correct Value", "[Scanner]") {
 	string TestFileContents = "print";
 	Scanner Scanner(TestFileContents, true);
 
-	assertScannerHasNextTokenOfTypeWithValue(Scanner, PRIMITIVE_KEYWORD, "print");
+	assertScannerHasNextTokenOfTypeWithValue(Scanner, IDENTIFIER, "print");
 }
 
 TEST_CASE("Scanner next() Returns IDENTIFIER for 'Print' with the Correct Value (AND NOT A PRIMITIVE KEYWORD)", "[Scanner]") {


### PR DESCRIPTION
Closes #18 
Closes #15

Updated Buildtokens to print newlines before error messages and removed "main" and "print" from the keyword map since they should just be identifiers